### PR TITLE
[FEATURE] Add classes for future/current/past days and events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Custom Home Assistant card displaying a responsive overview of multiple days wit
   - [Calendars](#calendars)
   - [Texts](#texts)
   - [Weather](#weather)
+- [Custom styling using cardmod](#custom-styling-using-cardmod)
 - [Examples](#examples)
 
 ## Installation
@@ -106,6 +107,29 @@ Custom Home Assistant card displaying a responsive overview of multiple days wit
 | `showTemperature`    | boolean | false        | `false` \| `true`            | Show temperature     | 1.1.0   |
 | `showLowTemperature` | boolean | false        | `false` \| `true`            | Show low temperature | 1.1.0   |
 
+## Custom styling using cardmod
+
+Like with most cards, you can add custom styling to this card using [card_mod](https://github.com/thomasloven/lovelace-card-mod). To make it easier to add custom styles to days and/or events, there are several classes that days and events can have.
+
+### Day classes
+
+| Class       | Description       | Version |
+|-------------|-------------------|---------|
+| `today`     | The current day   | 1.5.0   |
+| `tomorrow`  | The next day      | 1.5.0   |
+| `yesterday` | The previous day  | 1.5.0   |
+| `future`    | Day in the future | 1.5.0   |
+| `past`      | Day in the past   | 1.5.0   |
+
+### Event classes
+
+| Class     | Description              | Version |
+|-----------|--------------------------|---------|
+| `fullday` | Event lasts the full day | 1.5.0   |
+| `ongoing` | Currently ongoing        | 1.5.0   |
+| `future`  | Event in the future      | 1.5.0   |
+| `past`    | Event in the past        | 1.5.0   |
+
 ## Examples
 
 ### Minimal
@@ -155,4 +179,20 @@ texts:
   today: ''
   tomorrow: ''
   yesterday: ''
+```
+
+### Past events transparent with card_mod
+
+```yaml
+type: custom:week-planner-card
+calendars:
+  - entity: calendar.my_calendar_1
+    color: '#e6c229'
+  - entity: calendar.my_calendar_2
+    color: '#1a8fe3'
+card_mod:
+  style: |
+    .event.past {
+      opacity: .3;
+    }
 ```

--- a/src/card.js
+++ b/src/card.js
@@ -214,7 +214,7 @@ export class WeekPlannerCard extends LitElement {
                 }
                 
                 return html`
-                    <div class="day">
+                    <div class="day ${day.class}">
                         <div class="date">
                             <span class="number">${day.date.day}</span>
                             <span class="text">${this._getWeekDayText(day.date)}</span>
@@ -263,7 +263,7 @@ export class WeekPlannerCard extends LitElement {
                                 html`
                                     ${day.events.map((event) => {
                                         return html`
-                                            <div class="event" style="--border-color: ${event.color}" @click="${() => { this._handleEventClick(event) }}">
+                                            <div class="event ${event.class}" style="--border-color: ${event.color}" @click="${() => { this._handleEventClick(event) }}">
                                                 <div class="time">
                                                     ${event.fullDay ?
                                                         html`${this._language.fullDay}` :
@@ -510,8 +510,46 @@ export class WeekPlannerCard extends LitElement {
             originalEnd: this._convertApiDate(event.end),
             fullDay: fullDay,
             color: calendar.color ?? 'inherit',
-            calendar: calendar.entity
+            calendar: calendar.entity,
+            class: this._getEventClass(startDate, endDate, fullDay)
         });
+    }
+
+    _getEventClass(startDate, endDate, fullDay) {
+        let classes = [];
+        let now = DateTime.now();
+        if (fullDay) {
+            classes.push('fullday');
+        }
+        if (endDate < now) {
+            classes.push('past');
+        } else if (startDate <= now && endDate > now) {
+            classes.push('ongoing');
+        } else {
+            classes.push('future');
+        }
+        return classes.join(' ');
+    }
+
+    _getDayClass(startDate) {
+        let classes = [];
+        if (this._isToday(startDate)) {
+            classes.push('today');
+        } else if (this._isTomorrow(startDate)) {
+            classes.push('tomorrow');
+            classes.push('future');
+        } else if (this._isYesterday(startDate)) {
+            classes.push('yesterday');
+            classes.push('past');
+        } else {
+            let now = DateTime.now();
+            if (startDate > now) {
+                classes.push('future');
+            } else {
+                classes.push('past');
+            }
+        }
+        return classes.join(' ');
     }
 
     _handleMultiDayEvent(event, startDate, endDate, calendar) {
@@ -557,6 +595,7 @@ export class WeekPlannerCard extends LitElement {
                     date: startDate,
                     events: events,
                     weather: weatherForecast[dateKey] ?? null,
+                    class: this._getDayClass(startDate)
                 });
             }
 


### PR DESCRIPTION
This can be used for custom styling using card_mod. For example to make past events semi-transparent.

Resolves: #52
Resolves: #60