### PR TITLE
[FEATURE] Add calendar entity name to data attribute of event

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -263,7 +263,7 @@ export class WeekPlannerCard extends LitElement {
                                 html`
                                     ${day.events.map((event) => {
                                         return html`
-                                            <div class="event ${event.class}" style="--border-color: ${event.color}" @click="${() => { this._handleEventClick(event) }}">
+                                            <div class="event ${event.class}" data-entity="${event.calendar}" style="--border-color: ${event.color}" @click="${() => { this._handleEventClick(event) }}">
                                                 <div class="time">
                                                     ${event.fullDay ?
                                                         html`${this._language.fullDay}` :


### PR DESCRIPTION
This will make it possible to style events from different calendar entities differently using card_mod.

For example:

```yaml
card_mod:
  style: |
    .container .day .events .event {
      background-color: var(--border-color);
    }
    .container .day .events .event[data-entity="calendar.mycalendar"] {
      color: #ffffff;
      --secondary-text-color: #ffffff;
    }
```

Resolves: #71