### PR TITLE
[FEATURE] Add option to combine similar events

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Custom Home Assistant card displaying a responsive overview of multiple days wit
 | `hideDaysWithoutEvents`  | boolean          | false                                              | `false` \| `true`                                                                                                                           | Do not show days without events, except for today                                      | 1.4.0   |
 | `hideTodayWithoutEvents` | boolean          | false                                              | `false` \| `true`                                                                                                                           | Also do not show today without events if `hideDaysWithoutEvents` is set                | 1.8.0   |
 | `filter`                 | string           | optional                                           | Any regular expression                                                                                                                      | Remove events that match the regular expression                                        | 1.7.0   |
+| `combineSimilarEvents`   | boolean          | false                                              | `false` \| `true`                                                                                                                           | Combine events with the same start date/time, end date/time and title                  | 1.9.0   |
 
 ### Calendars
 

--- a/src/card.js
+++ b/src/card.js
@@ -55,6 +55,7 @@ export class WeekPlannerCard extends LitElement {
     _initialized = false;
     _loading = 0;
     _events = {};
+    _calendarEvents = {};
     _jsonDays = '';
     _calendars;
     _numberOfDays;
@@ -77,6 +78,7 @@ export class WeekPlannerCard extends LitElement {
     _hideDaysWithoutEvents;
     _hideTodayWithoutEvents;
     _filter;
+    _combineSimilarEvents;
     _showLegend;
     _actions;
 
@@ -128,6 +130,7 @@ export class WeekPlannerCard extends LitElement {
         this._hideDaysWithoutEvents = config.hideDaysWithoutEvents ?? false;
         this._hideTodayWithoutEvents = config.hideTodayWithoutEvents ?? false;
         this._filter = config.filter ?? false;
+        this._combineSimilarEvents = config.combineSimilarEvents ?? false;
         this._showLegend = config.showLegend ?? false;
         this._actions = config.actions ?? false;
         if (config.locale) {
@@ -306,32 +309,53 @@ export class WeekPlannerCard extends LitElement {
                                     </div>
                                 ` :
                                 html`
-                                    ${day.events.map((event) => {
-                                        return html`
-                                            <div class="event ${event.class}" data-entity="${event.calendar}" style="--border-color: ${event.color}" @click="${() => { this._handleEventClick(event) }}">
-                                                <div class="time">
-                                                    ${event.fullDay ?
-                                                        html`${this._language.fullDay}` :
-                                                        html`
-                                                            ${event.start.toFormat(this._timeFormat)}
-                                                            ${event.end ? ' - ' + event.end.toFormat(this._timeFormat) : ''}
+                                    ${day.events.map((eventKey) => {
+                                        const event = this._calendarEvents[eventKey];
+                                        if (!event) {
+                                            return html``;
+                                        } else {
+                                            return html`
+                                                <div
+                                                    class="event ${event.class}"
+                                                    data-entity="${event.calendar}"
+                                                    data-additional-entities="${event.otherCalendars.join(',')}"
+                                                    style="--border-color: ${event.color}"
+                                                    @click="${() => {
+                                                        this._handleEventClick(event)
+                                                    }}"
+                                                >
+                                                    ${event.otherColors.map((color) => {
+                                                        return html`
+                                                            <div class="additionalColor"
+                                                                 style="--event-additional-color: ${color}"></div>
                                                         `
-                                                    }
-                                                </div>
-                                                <div class="title">
-                                                    ${event.summary}
-                                                </div>
-                                                ${this._showLocation && event.location ?
-                                                    html`
-                                                        <div class="location">
-                                                            <ha-icon icon="mdi:map-marker"></ha-icon>
-                                                            ${event.location}
+                                                    })}
+                                                    <div class="inner">
+                                                        <div class="time">
+                                                            ${event.fullDay ?
+                                                                    html`${this._language.fullDay}` :
+                                                                    html`
+                                                                        ${event.start.toFormat(this._timeFormat)}
+                                                                        ${event.end ? ' - ' + event.end.toFormat(this._timeFormat) : ''}
+                                                                    `
+                                                            }
                                                         </div>
-                                                    ` :
-                                                    ''
-                                                }
-                                            </div>
-                                        `
+                                                        <div class="title">
+                                                            ${event.summary}
+                                                        </div>
+                                                        ${this._showLocation && event.location ?
+                                                                html`
+                                                                    <div class="location">
+                                                                        <ha-icon icon="mdi:map-marker"></ha-icon>
+                                                                        ${event.location}
+                                                                    </div>
+                                                                ` :
+                                                                ''
+                                                        }
+                                                    </div>
+                                                </div>
+                                            `
+                                        }
                                     })}
                                 `
                             }
@@ -357,7 +381,7 @@ export class WeekPlannerCard extends LitElement {
                     <div class="calendar">
                         <ha-icon icon="mdi:calendar-account"></ha-icon>
                         <div class="info">
-                            ${this.hass.formatEntityAttributeValue(this.hass.states[this._currentEventDetails.calendar], 'friendly_name')}
+                            ${this._currentEventDetails.calendarNames.join(', ')}
                         </div>
                     </div>
                     <div class="datetime">
@@ -480,6 +504,7 @@ export class WeekPlannerCard extends LitElement {
         this._isLoading = true;
         this._error = '';
         this._events = {};
+        this._calendarEvents = {};
 
         this._startDate = this._getStartDate();
         let startDate = this._startDate;
@@ -492,6 +517,12 @@ export class WeekPlannerCard extends LitElement {
 
         let calendarNumber = 0;
         this._calendars.forEach(calendar => {
+            if (!calendar.name) {
+                calendar = {
+                    ...calendar,
+                    name: this.hass.formatEntityAttributeValue(this.hass.states[calendar.entity], 'friendly_name')
+                }
+            }
             let calendarSorting = calendarNumber;
             this._loading++;
             this.hass.callApi(
@@ -519,6 +550,9 @@ export class WeekPlannerCard extends LitElement {
 
                 this._loading--;
             }).catch(error => {
+                if (!error.error) {
+                    console.log(error);
+                }
                 this._error = 'Error while fetching calendar: ' + error.error;
                 this._loading = 0;
                 throw new Error(this._error);
@@ -558,20 +592,42 @@ export class WeekPlannerCard extends LitElement {
             this._events[dateKey] = [];
         }
 
-        this._events[dateKey].push({
-            summary: event.summary ?? null,
-            description: event.description ?? null,
-            location: event.location ?? null,
-            start: startDate,
-            originalStart: this._convertApiDate(event.start),
-            end: endDate,
-            originalEnd: this._convertApiDate(event.end),
-            fullDay: fullDay,
-            color: calendar.color ?? 'inherit',
-            calendar: calendar.entity,
-            calendarSorting: calendarSorting,
-            class: this._getEventClass(startDate, endDate, fullDay)
-        });
+        let eventKey = startDate.toISO() + '-' + endDate.toISO() + '-' + event.summary;
+        if (!this._combineSimilarEvents) {
+            eventKey = startDate.toISO() + '-' + endDate.toISO() + '-' + event.summary + '-' + calendar.entity;
+        }
+
+        if (this._calendarEvents.hasOwnProperty(eventKey)) {
+            this._calendarEvents[eventKey].otherCalendars.push(calendar.entity);
+            if (calendar.color && this._calendarEvents[eventKey].otherColors.indexOf(calendar.color) === -1) {
+                this._calendarEvents[eventKey].otherColors.push(calendar.color)
+            }
+            if (calendar.name && this._calendarEvents[eventKey].calendarNames.indexOf(calendar.name) === -1) {
+                this._calendarEvents[eventKey].calendarNames.push(calendar.name);
+            }
+            if (calendarSorting < this._calendarEvents[eventKey].calendarSorting) {
+                this._calendarEvents[eventKey].calendarSorting = calendarSorting;
+            }
+        } else {
+            this._calendarEvents[eventKey] = {
+                summary: event.summary ?? null,
+                description: event.description ?? null,
+                location: event.location ?? null,
+                start: startDate,
+                originalStart: this._convertApiDate(event.start),
+                end: endDate,
+                originalEnd: this._convertApiDate(event.end),
+                fullDay: fullDay,
+                color: calendar.color ?? 'inherit',
+                otherColors: [],
+                calendar: calendar.entity,
+                otherCalendars: [],
+                calendarSorting: calendarSorting,
+                calendarNames: [calendar.name],
+                class: this._getEventClass(startDate, endDate, fullDay)
+            }
+            this._events[dateKey].push(eventKey);
+        }
     }
 
     _getEventClass(startDate, endDate, fullDay) {
@@ -656,11 +712,11 @@ export class WeekPlannerCard extends LitElement {
                 const dateKey = startDate.toISODate();
                 if (this._events.hasOwnProperty(dateKey)) {
                     events = this._events[dateKey].sort((event1, event2) => {
-                        if (event1.start === event2.start) {
-                            return event1.calendarSorting < event2.calendarSorting ? 1 : (event1.calendarSorting > event2.calendarSorting) ? -1 : 0;
+                        if (this._calendarEvents[event1].start === this._calendarEvents[event2].start) {
+                            return this._calendarEvents[event1].calendarSorting < this._calendarEvents[event2].calendarSorting ? 1 : (this._calendarEvents[event1].calendarSorting > this._calendarEvents[event2].calendarSorting) ? -1 : 0;
                         }
 
-                        return event1.start > event2.start ? 1 : -1;
+                        return this._calendarEvents[event1].start > this._calendarEvents[event2].start ? 1 : -1;
                     });
                 }
 

--- a/src/card.styles.js
+++ b/src/card.styles.js
@@ -137,7 +137,6 @@ export default css`
     .container .day .events .none,
     .container .day .events .event {
         margin-bottom: var(--event-spacing);
-        padding: var(--event-padding);
         background-color: var(--event-background-color);
         border-radius: 0 var(--event-border-radius) var(--event-border-radius) 0;
         font-size: var(--event-font-size);
@@ -145,12 +144,24 @@ export default css`
     }
 
     .container .day .events .none {
+        padding: var(--event-padding);
         border-radius: var(--event-border-radius);
     }
 
     .container .day .events .event {
+        display: flex;
         border-left: var(--event-border-width) solid var(--border-color, var(--divider-color, #ffffff));
         cursor: pointer;
+    }
+
+    .container .day .events .event .additionalColor {
+        width: var(--event-border-width);
+        background-color: var(--event-additional-color);
+    }
+
+    .container .day .events .event .inner {
+        flex-grow: 1;
+        padding: var(--event-padding);
     }
 
     .container .day .events .event .time {


### PR DESCRIPTION
This combines events from all calendars that have the same start date/time, end date/time and title. If you're using custom styling of events using card_mod, this might be a breaking change. Activate by setting the new `combineSimilarEvents` option to `true`.

Resolves: #76