### PR TITLE
[FEATURE] Add support for weather entities with twice_daily forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,13 @@ See [Actions documentation](https://www.home-assistant.io/dashboards/actions/). 
 
 ### Weather
 
-| Name                 | Type    | Default      | Supported options            | Description          | Version |
-|----------------------|---------|--------------|------------------------------|----------------------|---------|
-| `entity`             | string  | **Required** | `weather.my_weather_service` | Entity ID            | 1.1.0   |
-| `showCondition`      | boolean | true         | `false` \| `true`            | Show condition icon  | 1.1.0   |
-| `showTemperature`    | boolean | false        | `false` \| `true`            | Show temperature     | 1.1.0   |
-| `showLowTemperature` | boolean | false        | `false` \| `true`            | Show low temperature | 1.1.0   |
+| Name                 | Type    | Default      | Supported options            | Description                                                                    | Version |
+|----------------------|---------|--------------|------------------------------|--------------------------------------------------------------------------------|---------|
+| `entity`             | string  | **Required** | `weather.my_weather_service` | Entity ID                                                                      | 1.1.0   |
+| `useTwiceDaily`      | boolean | false        | `false` \| `true`            | Use twice daily forecast if your weather entity doesn't support daily forecast | 1.8.0   |
+| `showCondition`      | boolean | true         | `false` \| `true`            | Show condition icon                                                            | 1.1.0   |
+| `showTemperature`    | boolean | false        | `false` \| `true`            | Show temperature                                                               | 1.1.0   |
+| `showLowTemperature` | boolean | false        | `false` \| `true`            | Show low temperature                                                           | 1.1.0   |
 
 ## Custom styling using cardmod
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ See [Actions documentation](https://www.home-assistant.io/dashboards/actions/). 
 | Name                 | Type    | Default      | Supported options            | Description                                                                    | Version |
 |----------------------|---------|--------------|------------------------------|--------------------------------------------------------------------------------|---------|
 | `entity`             | string  | **Required** | `weather.my_weather_service` | Entity ID                                                                      | 1.1.0   |
-| `useTwiceDaily`      | boolean | false        | `false` \| `true`            | Use twice daily forecast if your weather entity doesn't support daily forecast | 1.8.0   |
+| `useTwiceDaily`      | boolean | false        | `false` \| `true`            | Use twice daily forecast if your weather entity doesn't support daily forecast | 1.9.0   |
 | `showCondition`      | boolean | true         | `false` \| `true`            | Show condition icon                                                            | 1.1.0   |
 | `showTemperature`    | boolean | false        | `false` \| `true`            | Show temperature                                                               | 1.1.0   |
 | `showLowTemperature` | boolean | false        | `false` \| `true`            | Show low temperature                                                           | 1.1.0   |

--- a/src/card.js
+++ b/src/card.js
@@ -496,7 +496,7 @@ export class WeekPlannerCard extends LitElement {
             }
         }, {
             type: 'weather/subscribe_forecast',
-            forecast_type: 'daily',
+            forecast_type: this._weather.useTwiceDaily ? 'twice_daily' : 'daily',
             entity_id: this._weather.entity
         });
     }
@@ -699,6 +699,11 @@ export class WeekPlannerCard extends LitElement {
         const weatherState = this._weather ? this.hass.states[this._weather.entity] : null;
         let weatherForecast = {};
         this._weatherForecast?.forEach((forecast) => {
+            // Only use day time forecasts
+            if (forecast.hasOwnProperty('is_daytime') && forecast.is_daytime === false) {
+                return;
+            }
+
             const dateKey = DateTime.fromISO(forecast.datetime).toISODate();
             weatherForecast[dateKey] = {
                 icon: this._getWeatherIcon(forecast),


### PR DESCRIPTION
Can be activated by setting the option `weather.useTwiceDaily` to `true`

Resolves: #140