### PR TITLE
Adding no events text option

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -175,6 +175,7 @@ export class WeekPlannerCard extends LitElement {
         this._hidePastEvents = config.hidePastEvents ?? false;
         this._hideDaysWithoutEvents = config.hideDaysWithoutEvents ?? false;
         this._hideTodayWithoutEvents = config.hideTodayWithoutEvents ?? false;
+        this._hideNoEventsText = config.hideNoEventsText ?? false;
         this._filter = config.filter ?? false;
         this._filterText = config.filterText ?? false;
         this._combineSimilarEvents = config.combineSimilarEvents ?? false;
@@ -425,7 +426,7 @@ export class WeekPlannerCard extends LitElement {
             dayEvents.push(event);
         });
 
-        if (dayEvents.length === 0) {
+        if (dayEvents.length === 0 && !this._hideNoEventsText) {
             return this._renderNoEvents();
         }
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -112,6 +112,7 @@ export class WeekPlannerCardEditor extends LitElement {
                         ${this.addBooleanField('hideWeekend', 'Hide weekend')}
                         ${this.addBooleanField('hideDaysWithoutEvents', 'Hide days without events except for today')}
                         ${this.addBooleanField('hideTodayWithoutEvents', 'Also hide today without events')}
+                        ${this.addBooleanField('hideNoEventsText', 'Hide the no events text')}
                         ${this.addTextField('maxDayEvents', 'Maximum number of events per day (0 is no maximum)', 'number', 0)}
                     `
                 )}


### PR DESCRIPTION
This PR adds an option to not render at all if there are no events for the day.

I like to be able to see that there is nothing going on for the day from really far away, so I would rather not see anything if there is no text. My workaround was to use a space instead of the "No Events" text, but this doesn't work too well if I use a transparent background. 

[Screencast_20250201_094844.webm](https://github.com/user-attachments/assets/4b058a2a-f349-4377-9adc-9a07796a918b)
