### PR TITLE
feat: Allow calendars to be initially hidden

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -191,7 +191,12 @@ export class WeekPlannerCard extends LitElement {
         this._columns = config.columns ?? {};
         this._maxEvents = config.maxEvents ?? false;
         this._maxDayEvents = config.maxDayEvents ?? false;
-        this._hideCalendars = [];
+        this._hideCalendars = (config.calendars || []).reduce((acc, calendar) => {
+            if (calendar.initiallyHidden && calendar.entity) {
+                acc.push(calendar.entity);
+            }
+            return acc;
+        }, []);
         if (config.locale) {
             LuxonSettings.defaultLocale = config.locale;
         }

--- a/src/editor.js
+++ b/src/editor.js
@@ -50,6 +50,7 @@ export class WeekPlannerCardEditor extends LitElement {
                                         ${this.addTextField('calendars.' + index + '.filter', 'Filter events (regex)')}
                                         ${this.addTextField('calendars.' + index + '.filterText', 'Filter event text (regex)')}
                                         ${this.addBooleanField('calendars.' + index + '.hideInLegend', 'Hide in legend')}
+                                        ${this.addBooleanField('calendars.' + index + '.initiallyHidden', 'Initially hide calendar events')}
                                         ${this.addButton('Remove calendar', 'mdi:trash-can', () => {
                                             const config = JSON.parse(JSON.stringify(this._config));
                                             if (config.calendars.length === 1) {


### PR DESCRIPTION
This change introduces an 'initiallyHidden' option for calendars. When set to true, the calendar's events will not be displayed on the card by default, but the calendar will still appear in the legend. Clicking the calendar in the legend will toggle the visibility of its events.

Added initiallyHidden boolean option to calendar configuration in src/editor.js.
Modified setConfig in src/card.js to populate _hideCalendars based on this new option at startup.