### PR TITLE
[FEATURE] Add duration to event elements for custom styling

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -496,7 +496,6 @@ export class WeekPlannerCard extends LitElement {
             ${dayEvents.map((event) => {
                 const doneColors = [event.colors[0]];
                 const durationMinutes = event.fullDay ? 24 * 60 : this._getEventDurationMinutes(event.start, event.end);
-                const durationType = this._getDurationType(durationMinutes);
                 return html`
                     <div
                         class="event ${event.class}"
@@ -509,7 +508,6 @@ export class WeekPlannerCard extends LitElement {
                         data-end-hour="${event.end.toFormat('H')}"
                         data-end-minute="${event.end.toFormat('mm')}"
                         data-duration="${durationMinutes}"
-                        data-duration-type="${durationType}"
                         style="--border-color: ${event.colors[0]}"
                         @click="${() => {
                             this._handleEventClick(event)
@@ -938,6 +936,10 @@ export class WeekPlannerCard extends LitElement {
         } else {
             classes.push('future');
         }
+        // Add duration class
+        const durationMinutes = fullDay ? 24 * 60 : this._getEventDurationMinutes(startDate, endDate);
+        const durationType = this._getDurationType(durationMinutes);
+        classes.push(`duration-${durationType}`);
         return classes.join(' ');
     }
 

--- a/src/card.js
+++ b/src/card.js
@@ -90,6 +90,22 @@ export class WeekPlannerCard extends LitElement {
     _navigationOffset = 0;
     _updateEventsTimeouts = [];
 
+    // Calculate duration in minutes
+    _getEventDurationMinutes(start, end) {
+        if (!start || !end) return 0;
+        return Math.round(end.diff(start, 'minutes').minutes);
+    }
+
+    // Categorize duration type
+    _getDurationType(minutes) {
+        if (minutes < 30) return 'XS';
+        if (minutes < 60) return 'Small';
+        if (minutes < 120) return 'Medium';
+        if (minutes < 240) return 'Large';
+        if (minutes < 360) return 'XL';
+        return 'XXL';
+    }
+
     /**
      * Get config element
      *
@@ -479,6 +495,8 @@ export class WeekPlannerCard extends LitElement {
         return html`
             ${dayEvents.map((event) => {
                 const doneColors = [event.colors[0]];
+                const durationMinutes = event.fullDay ? 24 * 60 : this._getEventDurationMinutes(event.start, event.end);
+                const durationType = this._getDurationType(durationMinutes);
                 return html`
                     <div
                         class="event ${event.class}"
@@ -490,6 +508,8 @@ export class WeekPlannerCard extends LitElement {
                         data-start-minute="${event.start.toFormat('mm')}"
                         data-end-hour="${event.end.toFormat('H')}"
                         data-end-minute="${event.end.toFormat('mm')}"
+                data-duration="${durationMinutes}"
+                data-duration-type="${durationType}"
                         style="--border-color: ${event.colors[0]}"
                         @click="${() => {
                             this._handleEventClick(event)

--- a/src/card.js
+++ b/src/card.js
@@ -98,12 +98,12 @@ export class WeekPlannerCard extends LitElement {
 
     // Categorize duration type
     _getDurationType(minutes) {
-        if (minutes < 30) return 'XS';
-        if (minutes < 60) return 'Small';
-        if (minutes < 120) return 'Medium';
-        if (minutes < 240) return 'Large';
-        if (minutes < 360) return 'XL';
-        return 'XXL';
+        if (minutes < 30) return 'xs';
+        if (minutes < 60) return 'small';
+        if (minutes < 120) return 'medium';
+        if (minutes < 240) return 'large';
+        if (minutes < 360) return 'xl';
+        return 'xxl';
     }
 
     /**
@@ -508,8 +508,8 @@ export class WeekPlannerCard extends LitElement {
                         data-start-minute="${event.start.toFormat('mm')}"
                         data-end-hour="${event.end.toFormat('H')}"
                         data-end-minute="${event.end.toFormat('mm')}"
-                data-duration="${durationMinutes}"
-                data-duration-type="${durationType}"
+                        data-duration="${durationMinutes}"
+                        data-duration-type="${durationType}"
                         style="--border-color: ${event.colors[0]}"
                         @click="${() => {
                             this._handleEventClick(event)


### PR DESCRIPTION
Added a separate class to event elements to indicate how long the event is:

- duration-xs - under 30 mins
- duration-small - under 1 hour
- duration-medium - under 2 hours
- duration-large - under 4 hours
- duration-xl - under 6 hours
- duration-xxl - 6+ hours

This can be then used to add additional style to events based on how long they are. For example, I've made large and xl events have a minimum height style, so they appear "bigger" in my event list.

Finally, added a `data-duration` data attribute (in integer minutes) for utility purposes.