### PR TITLE
[FEATURE] Expand month mode to display full calendar month

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -376,6 +376,9 @@ export class WeekPlannerCard extends LitElement {
         }
 
         return html`
+            ${this._startingDay === 'month' && Array.from({ length: (this._startDate.weekday - this._startingDayOffset - 1) % 7 }, (_, i) => html`
+                <div class="day"></div>`)
+            }
             ${this._days.map((day) => {
                 if (this._hideDaysWithoutEvents && day.events.length === 0 && (this._hideTodayWithoutEvents || !this._isToday(day.date))) {
                     return html``;
@@ -734,7 +737,7 @@ export class WeekPlannerCard extends LitElement {
 
         this._startDate = this._getStartDate();
         let startDate = this._startDate;
-        let endDate = this._startDate.plus({ days: this._numberOfDays });
+        let endDate = this._startDate.plus({ days: this._numberOfDaysIsMonth ? this._startDate.daysInMonth : this._numberOfDays });
         let now = DateTime.now();
         let runStartdate = this._startDate.toISO();
 
@@ -983,7 +986,7 @@ export class WeekPlannerCard extends LitElement {
         });
 
         let startDate = this._startDate;
-        let endDate = this._startDate.plus({ days: this._numberOfDays });
+        let endDate = this._startDate.plus({ days: this._numberOfDaysIsMonth ? this._startDate.daysInMonth : this._numberOfDays });
 
         let numberOfEvents = 0;
         while (startDate < endDate) {
@@ -1177,7 +1180,7 @@ export class WeekPlannerCard extends LitElement {
                 break;
         }
 
-        if (this._startingDayOffset !== 0) {
+        if (this._startingDayOffset !== 0 && ! this._numberOfDaysIsMonth) {
             startDate = startDate.plus({ days: this._startingDayOffset });
         }
 


### PR DESCRIPTION
This PR adds to the existing "month" feature to provide a calendar-like display, padding the start of the month to align to the designated start of the week. 

In month view, startingDayOffset no longer advances or regresses the displayed day, but will set the day that the week starts, 0 being Sunday, 1 Monday, etc. This was the easiest way to implement, but a separate field could be added for this instead.

This also adjusts the number of days shown in month view to match the currently selected month for the purposes of navigation.

This should address #139, #270, and #315.

Note: this does not work with hide weekend.