### PR TITLE
feat: persist navigation state

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -18,39 +18,40 @@ import sunny from 'data-url:./icons/sunny.png';
 import windy from 'data-url:./icons/windy.svg';
 
 const ICONS = {
-  'clear-day': sunny,
-  'clear-night': clear_night,
-  cloudy,
-  overcast: cloudy,
-  fog,
-  hail: mixed_rain,
-  lightning,
-  'lightning-rainy': storm,
-  'partly-cloudy-day': mostly_cloudy,
-  'partly-cloudy-night': mostly_cloudy_night,
-  partlycloudy: mostly_cloudy,
-  pouring: heavy_rain,
-  rain: rainy,
-  rainy,
-  sleet: mixed_rain,
-  snow: snowy,
-  snowy,
-  'snowy-rainy': mixed_rain,
-  sunny,
-  wind: windy,
-  windy,
-  'windy-variant': windy
+    'clear-day': sunny,
+    'clear-night': clear_night,
+    cloudy,
+    overcast: cloudy,
+    fog,
+    hail: mixed_rain,
+    lightning,
+    'lightning-rainy': storm,
+    'partly-cloudy-day': mostly_cloudy,
+    'partly-cloudy-night': mostly_cloudy_night,
+    partlycloudy: mostly_cloudy,
+    pouring: heavy_rain,
+    rain: rainy,
+    rainy,
+    sleet: mixed_rain,
+    snow: snowy,
+    snowy,
+    'snowy-rainy': mixed_rain,
+    sunny,
+    wind: windy,
+    windy,
+    'windy-variant': windy
 };
 
 const ICONS_NIGHT = {
-  ...ICONS,
-  sunny: clear_night,
-  partlycloudy: mostly_cloudy_night,
-  'lightning-rainy': storm_night
+    ...ICONS,
+    sunny: clear_night,
+    partlycloudy: mostly_cloudy_night,
+    'lightning-rainy': storm_night
 };
 
 export class WeekPlannerCard extends LitElement {
     static styles = styles;
+    static persistence = {};
 
     _initialized = false;
     _loading = 0;
@@ -154,6 +155,14 @@ export class WeekPlannerCard extends LitElement {
      */
     setConfig(config) {
         this._config = config;
+
+        if (config.card_id) {
+            if (WeekPlannerCard.persistence[config.card_id] !== undefined) {
+                this._navigationOffset = WeekPlannerCard.persistence[config.card_id];
+            } else {
+                WeekPlannerCard.persistence[config.card_id] = this._navigationOffset;
+            }
+        }
 
         if (!config.calendars) {
             throw new Error('No calendars are configured');
@@ -304,13 +313,13 @@ export class WeekPlannerCard extends LitElement {
             <ha-card class="${cardClasses.join(' ')}" style="${cardStyles.join(' ')}">
                 <div class="card-content">
                     ${this._error ?
-                        html`<div class="errors"><ha-alert alert-type="error">${this._error}</ha-alert></div>` :
-                        ''
-                    }
+                html`<div class="errors"><ha-alert alert-type="error">${this._error}</ha-alert></div>` :
+                ''
+            }
                     ${this._title ?
-                        html`<h1 class="card-title">${this._title}</h1>` :
-                        ''
-                    }
+                html`<h1 class="card-title">${this._title}</h1>` :
+                ''
+            }
                     <div class="container${this._actions ? ' hasActions' : ''}" @click="${this._handleContainerClick}">
                         ${this._renderHeader()}
                         ${this._renderWeekDays()}
@@ -345,20 +354,20 @@ export class WeekPlannerCard extends LitElement {
             <div class="legend">
                 <ul>
                     ${this._calendars.map((calendar) => {
-                        if (!calendar.hideInLegend) {
-                            return html`
+            if (!calendar.hideInLegend) {
+                return html`
                                 <li class="${calendar.icon ? 'icon' : 'noIcon'}${this._legendToggle ? ' hasToggle' : ''}${this._hideCalendars.indexOf(calendar.entity) === -1 ? '' : ' hidden'}" style="--legend-calendar-color: ${calendar.color ?? 'inherit'}" @click="${() => {
-                                    this._handleLegendClick(calendar)
-                                }}">
+                        this._handleLegendClick(calendar)
+                    }}">
                                     ${calendar.icon ?
-                                        html`<ha-icon icon="${calendar.icon}"></ha-icon>` :
-                                        ''
-                                    }
+                        html`<ha-icon icon="${calendar.icon}"></ha-icon>` :
+                        ''
+                    }
                                     ${calendar.name ?? calendar.entity}
                                 </li>
                             `;
-                        }
-                    })}
+            }
+        })}
                 </ul>
             </div>
         `;
@@ -404,14 +413,14 @@ export class WeekPlannerCard extends LitElement {
 
         return html`
             ${days.map((day) => {
-                return html`
+            return html`
                     <div class="day header">
                         <div class="date">
                             <span class="text">${weekDays[day.date.weekday]}</span>
                         </div>
                     </div>
                 `
-            })}
+        })}
         `;
     }
 
@@ -422,67 +431,67 @@ export class WeekPlannerCard extends LitElement {
 
         return html`
             ${this._days.map((day) => {
-                if (day.isOutsideMonth) {
-                    return html`<div class="day ${day.class}"></div>`;
-                }
+            if (day.isOutsideMonth) {
+                return html`<div class="day ${day.class}"></div>`;
+            }
 
-                if (this._hideDaysWithoutEvents && day.events.length === 0 && (this._hideTodayWithoutEvents || !this._isToday(day.date))) {
-                    return html``;
-                }
-                return html`
+            if (this._hideDaysWithoutEvents && day.events.length === 0 && (this._hideTodayWithoutEvents || !this._isToday(day.date))) {
+                return html``;
+            }
+            return html`
                     <div class="day ${day.class}" data-date="${day.date.day}" data-weekday="${day.date.weekday}" data-month="${day.date.month}" data-year="${day.date.year}" data-week="${day.date.weekNumber}">
                         <div class="date">
                             ${this._dayFormat ?
-                                unsafeHTML(day.date.toFormat(this._dayFormat)) :
-                                html`
+                    unsafeHTML(day.date.toFormat(this._dayFormat)) :
+                    html`
                                     <span class="number">${day.date.day}</span>
                                     ${this._showWeekDayText || (!this._numberOfDaysIsMonth && this._numberOfDays < 7) ?
-                                        html`<span class="text">${this._getWeekDayText(day.date)}</span>` :
-                                        ''
-                                    }
+                            html`<span class="text">${this._getWeekDayText(day.date)}</span>` :
+                            ''
+                        }
                                 `
-                            }
+                }
                         </div>
                         ${day.weather ?
-                            html`
+                    html`
                                 <div class="weather" @click="${this._handleWeatherClick}">
                                     ${this._weather?.showTemperature || this._weather?.showLowTemperature ?
-                                        html`
+                            html`
                                             <div class="temperature">
                                                 ${this._weather?.showTemperature ?
-                                                    html`
+                                    html`
                                                         <span class="high">${day.weather.temperature}</span>
                                                     ` :
-                                                    ''
-                                                }
+                                    ''
+                                }
                                                 ${this._weather?.showLowTemperature ?
-                                                    html`
+                                    html`
                                                             <span class="low">${day.weather.templow}</span>
                                                     ` :
-                                                    ''
-                                                }
+                                    ''
+                                }
                                             </div>
                                         ` :
-                                        ''
-                                    }
+                            ''
+                        }
                                     ${this._weather?.showCondition ?
-                                        html`
+                            html`
                                             <div class="icon">
                                                 <img src="${day.weather.icon}" alt="${day.weather.condition}">
                                             </div>
                                         ` :
-                                        ''
-                                    }
-                                </div>
-                            ` :
                             ''
                         }
+                                </div>
+                            ` :
+                    ''
+                }
                         <div class="events">
                             ${this._renderEvents(day)}
                         </div>
                     </div>
                 `
-            })}
+        })}
         `;
     }
 
@@ -530,8 +539,8 @@ export class WeekPlannerCard extends LitElement {
 
         return html`
             ${dayEvents.map((event) => {
-                const doneColors = [event.colors[0]];
-                return html`
+            const doneColors = [event.colors[0]];
+            return html`
                     <div
                         class="event ${event.class}"
                         data-entity="${event.calendars[0]}"
@@ -544,68 +553,68 @@ export class WeekPlannerCard extends LitElement {
                         data-end-minute="${event.end.toFormat('mm')}"
                         style="--border-color: ${event.colors[0]}"
                         @click="${() => {
-                            this._handleEventClick(event)
-                        }}"
+                    this._handleEventClick(event)
+                }}"
                     >
                         ${event.colors.map((color) => {
-                            if (doneColors.indexOf(color) > -1) {
-                                return '';
-                            }
-                            doneColors.push(color);
-                            return html`
+                    if (doneColors.indexOf(color) > -1) {
+                        return '';
+                    }
+                    doneColors.push(color);
+                    return html`
                                 <div
                                     class="additionalColor"
                                     style="--event-additional-color: ${color}"
                                 ></div>
                             `
-                        })}
+                })}
                         <div class="inner">
                             <div class="time">
                                 ${event.fullDay ?
-                                    html`${this._language.fullDay}` :
-                                    html`
+                    html`${this._language.fullDay}` :
+                    html`
                                         ${event.start.toFormat(this._timeFormat)}
                                         ${event.end ? ' - ' + event.end.toFormat(this._timeFormat) : ''}
                                     `
-                                }
+                }
                             </div>
                             ${this._showTitle ?
-                                    html`
+                    html`
                                         <div class="title">
                                             ${event.summary}
                                         </div>
                                     ` :
-                                    ''
-                            }
+                    ''
+                }
                             ${this._showDescription ?
-                                html`
+                    html`
                                     <div class="description">
                                         ${unsafeHTML(event.description)}
                                     </div>
                                 ` :
-                                ''
-                            }
+                    ''
+                }
                             ${this._showLocation && event.location ?
-                                html`
+                    html`
                                     <div class="location">
                                         <ha-icon icon="mdi:map-marker"></ha-icon>
                                         ${event.location}
                                     </div>
                                 ` :
-                                ''
-                            }
+                    ''
+                }
                         </div>
                         ${event.icon ?
-                            html`
+                    html`
                                 <div class="icon">
                                     <ha-icon icon="${event.icon}"></ha-icon>
                                 </div>
                             ` :
-                            ''
-                        }
+                    ''
+                }
                     </div>
                 `
-            })}
+        })}
             ${moreEvents ?
                 html`
                     <div class="more">
@@ -650,7 +659,7 @@ export class WeekPlannerCard extends LitElement {
                         </div>
                     </div>
                     ${this._currentEventDetails.location ?
-                        html`
+                html`
                             <div class="location">
                                 <ha-icon icon="mdi:map-marker"></ha-icon>
                                 <div class="info">
@@ -658,16 +667,16 @@ export class WeekPlannerCard extends LitElement {
                                 </div>
                             </div>
                         ` :
-                        ''
-                    }
+                ''
+            }
                     ${this._currentEventDetails.description ?
-                        html`
+                html`
                             <div class="description">
                                 ${unsafeHTML(this._currentEventDetails.description)}
                             </div>
                         ` :
-                        ''
-                    }
+                ''
+            }
                 </div>
             </ha-dialog>
         `;
@@ -1135,9 +1144,9 @@ export class WeekPlannerCard extends LitElement {
 
         const event = new Event(
             'hass-action', {
-                bubbles: true,
-                composed: true,
-            }
+            bubbles: true,
+            composed: true,
+        }
         );
         event.detail = {
             config: this._actions,
@@ -1177,24 +1186,46 @@ export class WeekPlannerCard extends LitElement {
     _handleNavigationOriginalClick() {
         this._navigationOffset = 0;
         this._updateEvents();
+        this._savePersistence();
     }
 
     _handleNavigationNextClick(event) {
         this._navigationOffset++;
         this._updateEvents();
+        this._savePersistence();
     }
 
     _handleNavigationPreviousClick(event) {
         this._navigationOffset--;
         this._updateEvents();
+        this._savePersistence();
+    }
+
+    _savePersistence() {
+        if (this._config?.card_id) {
+            WeekPlannerCard.persistence[this._config.card_id] = this._navigationOffset;
+        }
+
+        const event = new Event(
+            'week-planner-date-changed', {
+            bubbles: true,
+            composed: true,
+        }
+        );
+        event.detail = {
+            startDate: this._startDate.toISO(),
+            navigationOffset: this._navigationOffset,
+            card_id: this._config?.card_id
+        }
+        this.dispatchEvent(event);
     }
 
     _handleWeatherClick(e) {
         const event = new Event(
             'hass-more-info', {
-                bubbles: true,
-                composed: true,
-            }
+            bubbles: true,
+            composed: true,
+        }
         );
         event.detail = {
             entityId: this._weather.entity


### PR DESCRIPTION
**Feature: Persist Navigation State**
**Problem**
The week-planner-card previously lost its navigation state (current date view) whenever the component was re-rendered or the configuration changed (e.g., adding/toggling calendars). This caused the view to reset to "today", frustrating users who were navigating through future/past dates.

**Solution**
Implemented a persistence mechanism using a static class property WeekPlannerCard.persistence to store the navigation offset for each card instance.

**Key Changes**

1.  __card_id_ **Configuration**: Added a new optional configuration parameter card_id. If provided, the card uses this ID to key its state in the persistent storage.

2. **State Persistence:** The __navigationOffset_ (which determines the viewed date range) is saved to _WeekPlannerCard.persistence[card_id]_ whenever navigation occurs (next/prev/today).
3. **State Restoration**: When  setConfig  is called (e.g., on dashboard refresh or config update), the card checks for an existing state for the given card_id and restores the _navigationOffset.
4. Events: Dispatches a new week-planner-date-changed event whenever the navigation changes, containing the startDate, navigationOffset, and card_id.

**Configuration Example**

```
yaml
type: custom:week-planner-card
card_id: my_planner_main  # Unique ID required for persistence
calendars:
  - entity: calendar.family
```
**Verification**
verified that adding card_id preserves the view when toggling other config options.
verified that without card_id, behavior remains unchanged (no persistence).